### PR TITLE
Version 0.9.5.0

### DIFF
--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3765,7 +3765,7 @@ local function OnSessionLoaded()
             DelayedCallUntil(
                 function() return WaitRemoveBoostingMany(SessionContext, entitiesNeedingBoosts) end,
                 function()
-                    PerformBoostingMany(SessionContext, affectedEntities)
+                    PerformBoostingMany(SessionContext, entitiesNeedingBoosts)
                 end
             )
         end
@@ -3807,7 +3807,7 @@ local function OnSessionLoaded()
                 DelayedCallUntil(
                     function() return WaitRemoveBoostingMany(SessionContext, entitiesNeedingBoosts) end,
                     function()
-                        PerformBoostingMany(SessionContext, affectedEntities)
+                        PerformBoostingMany(SessionContext, entitiesNeedingBoosts)
                     end
                 )
             end
@@ -3839,7 +3839,7 @@ local function OnSessionLoaded()
 
                 -- After removing passives, it takes some time for them to actually disappear
                 DelayedCallUntil(
-                    function() return WaitRemoveBoostingMany(SessionContext, affectedEntities) end,
+                    function() return WaitRemoveBoostingMany(SessionContext, entitiesNeedingBoosts) end,
                     function()
                         PerformBoostingMany(SessionContext, entitiesNeedingBoosts)
                     end

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -41,6 +41,24 @@ function SafeGetWithDefault(default, object, ...)
     end
 end
 
+---Copies an object deeply
+--- @generic T : any
+---@param original T
+---@return T
+function DeepCopy(original)
+    local originalType = type(original)
+    local copy = nil
+    if originalType == 'table' then
+        copy = {}
+        for originalKey, originalValue in next, original, nil do
+            copy[DeepCopy(originalKey)] = DeepCopy(originalValue)
+        end
+    else
+        copy = original
+    end
+    return copy
+end
+
 -- Courtesy to @Eralyne on Discord
 ---Delay a function call by the given time
 ---@param ms integer
@@ -248,6 +266,14 @@ function ArrayToList(array)
         table.insert(list, elem)
     end
     return list
+end
+
+function Reverse(listlike)
+    local result = DeepCopy(listlike)
+    for i = 1, #listlike//2, 1 do
+        result[i], result[#listlike-i+1] = listlike[#listlike-i+1], listlike[i]
+    end
+    return result
 end
 
 function Flatten(listOfLists)

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3523,14 +3523,22 @@ end
 function RemoveBoostingMany(sessionContext, entities, force)
     sessionContext.Log(1, "Removing Many Boosting")
 
+    local affectedEntities = {}
+    local unAffectedEntities = {}
+    local unBoostedEntities = {}
     for _, entity in ipairs(entities) do
-        if force or (
-            entity.Vars.LCC_Boosted.General and
-            entity.Vars.LCC_BoostedWithHash.Hash ~= SessionContext.ConfigHash
-        ) then
-            RemoveAllFromEntity(sessionContext, entity)
+        if force or entity.Vars.LCC_Boosted.General then
+            if force or entity.Vars.LCC_BoostedWithHash.Hash ~= SessionContext.ConfigHash then
+                RemoveAllFromEntity(sessionContext, entity)
+                table.insert(affectedEntities, entity)
+            else
+                table.insert(unAffectedEntities, entity)
+            end
+        else
+            table.insert(unBoostedEntities, entity)
         end
     end
+    return affectedEntities, unAffectedEntities, unBoostedEntities
 end
 
 function WaitRemoveBoostingMany(sessionContext, entities)
@@ -3632,12 +3640,15 @@ local function OnSessionLoaded()
 
             SetupUserVars(SessionContext, entities)
 
-            RemoveBoostingMany(SessionContext, entities)
+            local affectedEntities, unAffectedEntities, unBooostedEntities = RemoveBoostingMany(SessionContext, entities)
+
+            local entitiesNeedingBoosts = {}
+            entitiesNeedingBoosts = TableCombine(unBooostedEntities, TableCombine(affectedEntities, entitiesNeedingBoosts))
 
             DelayedCallUntil(
-                function() return WaitRemoveBoostingMany(SessionContext, entities) end,
+                function() return WaitRemoveBoostingMany(SessionContext, affectedEntities) end,
                 function()
-                    PerformBoostingMany(SessionContext, entities)
+                    PerformBoostingMany(SessionContext, entitiesNeedingBoosts)
                 end
             )
         end
@@ -3651,12 +3662,15 @@ local function OnSessionLoaded()
 
             SetupUserVars(SessionContext, entities)
 
-            RemoveBoostingMany(SessionContext, entities)
+            local affectedEntities, unAffectedEntities, unBooostedEntities = RemoveBoostingMany(SessionContext, entities)
+
+            local entitiesNeedingBoosts = {}
+            entitiesNeedingBoosts = TableCombine(unBooostedEntities, TableCombine(affectedEntities, entitiesNeedingBoosts))
 
             DelayedCallUntil(
-                function() return WaitRemoveBoostingMany(SessionContext, entities) end,
+                function() return WaitRemoveBoostingMany(SessionContext, affectedEntities) end,
                 function()
-                    PerformBoostingMany(SessionContext, entities)
+                    PerformBoostingMany(SessionContext, entitiesNeedingBoosts)
                 end
             )
         end
@@ -3676,13 +3690,16 @@ local function OnSessionLoaded()
 
             local entities = Ext.Entity.GetAllEntitiesWithComponent("ServerCharacter")
 
-            RemoveBoostingMany(SessionContext, entities)
+            local affectedEntities, unAffectedEntities, unBooostedEntities = RemoveBoostingMany(SessionContext, entities)
+
+            local entitiesNeedingBoosts = {}
+            entitiesNeedingBoosts = TableCombine(unBooostedEntities, TableCombine(affectedEntities, entitiesNeedingBoosts))
 
             -- After removing passives, it takes some time for them to actually disappear
             DelayedCallUntil(
-                function() return WaitRemoveBoostingMany(SessionContext, entities) end,
+                function() return WaitRemoveBoostingMany(SessionContext, entitiesNeedingBoosts) end,
                 function()
-                    PerformBoostingMany(SessionContext, entities)
+                    PerformBoostingMany(SessionContext, entitiesNeedingBoosts)
                 end
             )
         end
@@ -3705,13 +3722,16 @@ local function OnSessionLoaded()
                 return
             end
 
-            RemoveBoostingMany(SessionContext, entities)
+            local affectedEntities, unAffectedEntities, unBooostedEntities = RemoveBoostingMany(SessionContext, entities)
+
+            local entitiesNeedingBoosts = {}
+            entitiesNeedingBoosts = TableCombine(unBooostedEntities, TableCombine(affectedEntities, entitiesNeedingBoosts))
 
             -- After removing passives, it takes some time for them to actually disappear
             DelayedCallUntil(
-                function() return WaitRemoveBoostingMany(SessionContext, entities) end,
+                function() return WaitRemoveBoostingMany(SessionContext, entitiesNeedingBoosts) end,
                 function()
-                    PerformBoostingMany(SessionContext, entities)
+                    PerformBoostingMany(SessionContext, affectedEntities)
                 end
             )
         end
@@ -3744,13 +3764,16 @@ local function OnSessionLoaded()
                 local entity = Ext.Entity.Get(string.sub(target, -36))
                 local entities = {entity}
 
-                RemoveBoostingMany(SessionContext, entities, true)
+                local affectedEntities, unAffectedEntities, unBooostedEntities = RemoveBoostingMany(SessionContext, entities, true)
+
+                local entitiesNeedingBoosts = {}
+                entitiesNeedingBoosts = TableCombine(unBooostedEntities, TableCombine(affectedEntities, entitiesNeedingBoosts))
 
                 -- After removing passives, it takes some time for them to actually disappear
                 DelayedCallUntil(
-                    function() return WaitRemoveBoostingMany(SessionContext, entities) end,
+                    function() return WaitRemoveBoostingMany(SessionContext, entitiesNeedingBoosts) end,
                     function()
-                        PerformBoostingMany(SessionContext, entities)
+                        PerformBoostingMany(SessionContext, affectedEntities)
                     end
                 )
             end
@@ -3775,13 +3798,16 @@ local function OnSessionLoaded()
             if statusID == "LCC_ALL_REBOOST" then
                 local entities = Ext.Entity.GetAllEntitiesWithComponent("ServerCharacter")
 
-                RemoveBoostingMany(SessionContext, entities, true)
+                local affectedEntities, unAffectedEntities, unBooostedEntities = RemoveBoostingMany(SessionContext, entities, true)
+
+                local entitiesNeedingBoosts = {}
+                entitiesNeedingBoosts = TableCombine(unBooostedEntities, TableCombine(affectedEntities, entitiesNeedingBoosts))
 
                 -- After removing passives, it takes some time for them to actually disappear
                 DelayedCallUntil(
-                    function() return WaitRemoveBoostingMany(SessionContext, entities) end,
+                    function() return WaitRemoveBoostingMany(SessionContext, affectedEntities) end,
                     function()
-                        PerformBoostingMany(SessionContext, entities)
+                        PerformBoostingMany(SessionContext, entitiesNeedingBoosts)
                     end
                 )
             end

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -2017,6 +2017,8 @@ function ComputeNewSpells(sessionContext, target, configType)
     local selectedSpells = {}
 
     local npcLevel = tonumber(Osi.GetLevel(target))
+    local entity = Ext.Entity.Get(target)
+    local spellCastingAbility = entity.Stats.SpellCastingAbility
     local npcSpellTable = {}
 
     local spellTables = {}
@@ -2112,7 +2114,7 @@ function ComputeNewSpells(sessionContext, target, configType)
             end
         end
     end
-    return MapTableValues(function(spellVal) return string.format("UnlockSpell(%s,,%s)", spellVal, sessionContext.ActionResources["SpellSlot"]) end, finalSelectedSpells)
+    return MapTableValues(function(spellVal) return string.format("UnlockSpell(%s,,%s,,%s)", spellVal, sessionContext.ActionResources["SpellSlot"], spellCastingAbility) end, finalSelectedSpells)
 end
 
 --- @param sessionContext SessionContext

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3505,8 +3505,8 @@ function RemoveAllFromEntity(sessionContext, entity)
     entity.Vars.LCC_BoostedWithHash = {Hash = nil}
 end
 
-function RemoveAllBoosting(sessionContext)
-    sessionContext.Log(1, "Removing ALL Boosting")
+function RemoveBoostingMany(sessionContext, entities)
+    sessionContext.Log(1, "Removing Many Boosting")
 
     for _, entity in ipairs(entities) do
         if (
@@ -3518,11 +3518,24 @@ function RemoveAllBoosting(sessionContext)
     end
 end
 
-function PerformAllBoosting(sessionContext)
-    sessionContext.Log(1, "Performing ALL Boosting")
+function WaitRemoveBoostingMany(sessionContext, entities)
+    local allGone = true
+    for _, entity in ipairs(entities) do
+        local boosts = OurBoosts(nil, entity)
+        sessionContext.Log(3, string.format("Waiting for all boosts to be gone: %s %s %s", entity.Uuid.EntityUuid, #boosts, allGone))
+        if #boosts > 0 then
+            allGone = false
+            break
+        end
+    end
+    return allGone
+end
 
-    for _, e in ipairs(Ext.Entity.GetAllEntitiesWithComponent("ServerCharacter")) do
-        PerformBoosting(sessionContext, e.Uuid.EntityUuid)
+function PerformBoostingMany(sessionContext, entities)
+    sessionContext.Log(1, "Performing Many Boosting")
+
+    for _, entity in ipairs(entities) do
+        PerformBoosting(sessionContext, entity.Uuid.EntityUuid)
     end
 end
 

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3190,16 +3190,7 @@ function ResetConfigJson(sessionContext)
 end
 
 function ComputeConfigHash(sessionContext)
-    return NestedVisitTable(
-        sessionContext.VarsJson,
-        function(str) return ConsistentHash(1234, 100, tostring(str)) end,
-        function(elems) return Fold(
-                function(x, y) return x + y end,
-                0,
-                elems
-            )
-        end
-    )
+    return ConsistentHash(1234, 1000000000, Ext.Json.Stringify(sessionContext.VarsJson))
 end
 
 --- @param sessionContext SessionContext

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3317,6 +3317,7 @@ function GiveBoosts(sessionContext, guid, configType)
     end
 
     entity.Vars.LCC_Boosted = {General = true}
+    entity.Vars.LCC_BoostedWithHash = {Hash = sessionContext.ConfigHash}
 end
 
 
@@ -3335,6 +3336,11 @@ function PerformBoosting(sessionContext, guid)
     if entity.Vars.LCC_Boosted == nil then
         entity.Vars.LCC_Boosted = {
             General = false,
+        }
+    end
+    if entity.Vars.LCC_BoostedWithHash == nil then
+        entity.Vars.LCC_BoostedWithHash = {
+            Hash = nil,
         }
     end
 
@@ -3480,6 +3486,11 @@ function RemoveAllFromEntity(sessionContext, entity)
             General = false,
         }
     end
+    if entity.Vars.LCC_BoostedWithHash == nil then
+        entity.Vars.LCC_BoostedWithHash = {
+            Hash = nil,
+        }
+    end
 
     local shortGuid = string.sub(entity.Uuid.EntityUuid, -36)
     sessionContext.Log(2, string.format("Removing All for Guid: %s", shortGuid))
@@ -3491,13 +3502,19 @@ function RemoveAllFromEntity(sessionContext, entity)
     RemovePassives(sessionContext, entity, nil)
 
     entity.Vars.LCC_Boosted = {General = false}
+    entity.Vars.LCC_BoostedWithHash = {Hash = nil}
 end
 
 function RemoveAllBoosting(sessionContext)
     sessionContext.Log(1, "Removing ALL Boosting")
 
-    for _, e in ipairs(Ext.Entity.GetAllEntitiesWithComponent("ServerCharacter")) do
-        RemoveAllFromEntity(sessionContext, e)
+    for _, entity in ipairs(entities) do
+        if (
+            entity.Vars.LCC_Boosted.General and
+            entity.Vars.LCC_BoostedWithHash.Hash ~= SessionContext.ConfigHash
+        ) then
+            RemoveAllFromEntity(sessionContext, entity)
+        end
     end
 end
 
@@ -3861,6 +3878,7 @@ end
 
 Ext.Vars.RegisterUserVariable("LCC_PassivesAdded", {Server=true, Persistent=true, DontCache=true})
 Ext.Vars.RegisterUserVariable("LCC_Boosted", {Server=true, Persistent=true, DontCache=true})
+Ext.Vars.RegisterUserVariable("LCC_BoostedWithHash", {Server=true, Persistent=true, DontCache=true})
 Ext.Vars.RegisterUserVariable("LCC_DebugMode_RestoreSettings", {Server=true, Persistent=true, DontCache=true})
 
 Ext.Events.SessionLoaded:Subscribe(OnSessionLoaded)

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3739,7 +3739,7 @@ function DummySessionContext()
 end
 
 local function OnSessionLoaded()
-    _Log(DummySessionContext(), 0, "0.9.4.0")
+    _Log(DummySessionContext(), 0, "0.9.5.0")
 
     if IsCriticalMissLoaded() then
         ProtectedPassives["Passive_CriticalMiss"] = true

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3189,6 +3189,19 @@ function ResetConfigJson(sessionContext)
     GetVarsJson(sessionContext)
 end
 
+function ComputeConfigHash(sessionContext)
+    return NestedVisitTable(
+        sessionContext.VarsJson,
+        function(str) return ConsistentHash(1234, 100, tostring(str)) end,
+        function(elems) return Fold(
+                function(x, y) return x + y end,
+                0,
+                elems
+            )
+        end
+    )
+end
+
 --- @param sessionContext SessionContext
 function GetVarsJson(sessionContext)
     local configStr = Ext.IO.LoadFile(string.format("%s.json", ModName))
@@ -3219,6 +3232,7 @@ function GetVarsJson(sessionContext)
             UnDebugMode(SessionContext, guid)
         end
     end
+    sessionContext.ConfigHash = ComputeConfigHash(sessionContext)
 end
 
 --- @param sessionContext SessionContext

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3523,11 +3523,11 @@ function SetupUserVars(sessionContext, entities)
     end
 end
 
-function RemoveBoostingMany(sessionContext, entities)
+function RemoveBoostingMany(sessionContext, entities, force)
     sessionContext.Log(1, "Removing Many Boosting")
 
     for _, entity in ipairs(entities) do
-        if (
+        if force or (
             entity.Vars.LCC_Boosted.General and
             entity.Vars.LCC_BoostedWithHash.Hash ~= SessionContext.ConfigHash
         ) then
@@ -3747,7 +3747,7 @@ local function OnSessionLoaded()
                 local entity = Ext.Entity.Get(string.sub(target, -36))
                 local entities = {entity}
 
-                RemoveBoostingMany(SessionContext, entities)
+                RemoveBoostingMany(SessionContext, entities, true)
 
                 -- After removing passives, it takes some time for them to actually disappear
                 DelayedCallUntil(
@@ -3763,7 +3763,7 @@ local function OnSessionLoaded()
 
                 local entities = {entity}
 
-                RemoveBoostingMany(SessionContext, entities)
+                RemoveBoostingMany(SessionContext, entities, true)
             end
 
             if statusID == "LCC_BOOST" then
@@ -3778,7 +3778,7 @@ local function OnSessionLoaded()
             if statusID == "LCC_ALL_REBOOST" then
                 local entities = Ext.Entity.GetAllEntitiesWithComponent("ServerCharacter")
 
-                RemoveBoostingMany(SessionContext, entities)
+                RemoveBoostingMany(SessionContext, entities, true)
 
                 -- After removing passives, it takes some time for them to actually disappear
                 DelayedCallUntil(
@@ -3792,7 +3792,7 @@ local function OnSessionLoaded()
             if statusID == "LCC_ALL_UNBOOST" then
                 local entities = Ext.Entity.GetAllEntitiesWithComponent("ServerCharacter")
 
-                RemoveBoostingMany(SessionContext, entities)
+                RemoveBoostingMany(SessionContext, entities, true)
             end
 
             if statusID == "LCC_ALL_BOOST" then

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3313,7 +3313,7 @@ function GiveBoosts(sessionContext, guid, configType)
     end
 
     for _, boost in ipairs(allBoosts) do
-        SessionContext.LogI(3, 24, string.format("Adding boost %s to %s", boost, guid))
+        sessionContext.LogI(3, 24, string.format("Adding boost %s to %s", boost, guid))
         AddBoostsAdv(guid, boost)
     end
 

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3505,6 +3505,24 @@ function RemoveAllFromEntity(sessionContext, entity)
     entity.Vars.LCC_BoostedWithHash = {Hash = nil}
 end
 
+function SetupUserVars(sessionContext, entities)
+    for _, entity in ipairs(entities) do
+        if entity.Vars.LCC_Boosted == nil then
+            entity.Vars.LCC_Boosted = {
+                General = false,
+            }
+        end
+        if entity.Vars.LCC_BoostedWithHash == nil then
+            entity.Vars.LCC_BoostedWithHash = {
+                Hash = nil,
+            }
+        end
+        if entity.Vars.LCC_PassivesAdded == nil then
+            entity.Vars.LCC_PassivesAdded = {}
+        end
+    end
+end
+
 function RemoveBoostingMany(sessionContext, entities)
     sessionContext.Log(1, "Removing Many Boosting")
 
@@ -3614,6 +3632,9 @@ local function OnSessionLoaded()
             local entity = Ext.Entity.Get(shortGuid)
 
             local entities = {entity}
+
+            SetupUserVars(SessionContext, entities)
+
             RemoveBoostingMany(SessionContext, entities)
 
             DelayedCallUntil(
@@ -3630,6 +3651,9 @@ local function OnSessionLoaded()
             local entity = Ext.Entity.Get(shortGuid)
 
             local entities = {entity}
+
+            SetupUserVars(SessionContext, entities)
+
             RemoveBoostingMany(SessionContext, entities)
 
             DelayedCallUntil(
@@ -3676,10 +3700,13 @@ local function OnSessionLoaded()
             SessionContext.EntityCache = {}
             GetVarsJson(SessionContext)
 
+            local entities = Ext.Entity.GetAllEntitiesWithComponent("ServerCharacter")
+
+            SetupUserVars(SessionContext, entities)
+
             if SafeGetWithDefault(false, SessionContext.VarsJson, "DebugMode", "DisableLevelGameplayStart") then
                 return
             end
-            local entities = Ext.Entity.GetAllEntitiesWithComponent("ServerCharacter")
 
             RemoveBoostingMany(SessionContext, entities)
 

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3641,6 +3641,20 @@ local function OnSessionLoaded()
     --- @type SessionContext
     SessionContext = CreateSessionContext()
 
+    Ext.Osiris.RegisterListener("LevelLoaded", 1, "before", function(level)
+            _Log(DummySessionContext(), 2, "LevelLoaded: Before")
+
+            SessionContext.EntityCache = {}
+            GetVarsJson(SessionContext)
+
+        end
+    )
+
+    Ext.Osiris.RegisterListener("LevelLoaded", 1, "after", function(level)
+            _Log(DummySessionContext(), 2, "LevelLoaded: After")
+        end
+    )
+
     Ext.Osiris.RegisterListener("EnteredLevel", 3, "before", function(guid, _objectRootTemplate, level)
             SessionContext.Log(1, string.format("EnteredLevel: Guid: %s", guid))
             local shortGuid = string.sub(guid, -36)

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -1,4 +1,7 @@
 ModName = "LoreCombatConfigurator"
+-- IMPORTANT: When the config is changed internally in a way that wont be reflected in its text by a user
+-- (defaults, inheritance, fallbacks), This value must be changed.
+CONFIG_HASH_SALT = 1234
 
 -- Courtesy to @Buns on Discord
 function SafeGet(object, ...)
@@ -3190,7 +3193,14 @@ function ResetConfigJson(sessionContext)
 end
 
 function ComputeConfigHash(sessionContext)
-    return ConsistentHash(1234, 1000000000, Ext.Json.Stringify(sessionContext.VarsJson))
+    local opts = {
+        Beautify = false,
+        StringifyInternalTypes = true,
+        IterateUserdata = true,
+        AvoidRecursion = false,
+    }
+    local stringifiedConfig = Ext.Json.Stringify(sessionContext.VarsJson)
+    return ConsistentHash(CONFIG_HASH_SALT, #stringifiedConfig * 256, stringifiedConfig)
 end
 
 --- @param sessionContext SessionContext

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3656,6 +3656,7 @@ local function OnSessionLoaded()
     )
 
     Ext.Osiris.RegisterListener("EnteredLevel", 3, "before", function(guid, _objectRootTemplate, level)
+            _Log(DummySessionContext(), 2, string.format("EnteredLevel: Guid: %s", guid))
             SessionContext.Log(1, string.format("EnteredLevel: Guid: %s", guid))
             local shortGuid = string.sub(guid, -36)
             local entity = Ext.Entity.Get(shortGuid)
@@ -3678,6 +3679,7 @@ local function OnSessionLoaded()
         end
     )
     Ext.Osiris.RegisterListener("EnteredCombat", 2, "after", function(guid, combatid)
+            _Log(DummySessionContext(), 2, string.format("EnteredCombat: Guid: %s; combatid: %s", guid, combatid))
             SessionContext.Log(1, string.format("EnteredCombat: Guid: %s; combatid: %s", guid, combatid))
             local shortGuid = string.sub(guid, -36)
             local entity = Ext.Entity.Get(shortGuid)
@@ -3701,12 +3703,14 @@ local function OnSessionLoaded()
     )
 
     Ext.Osiris.RegisterListener("CombatEnded",1,"after",function(combatid)
+            _Log(DummySessionContext(), 1, string.format("CombatEnded: combatid: %s\n", combatid))
             SessionContext.Log(1, string.format("CombatEnded: combatid: %s\n", combatid))
         end
     )
 
 
     Ext.Osiris.RegisterListener("PingRequested",1,"after",function(_)
+            _Log(DummySessionContext(), 1, "PingRequested")
             SessionContext.Log(1, "PingRequested: Removing Current Boosts")
 
             SessionContext.EntityCache = {}
@@ -3733,6 +3737,7 @@ local function OnSessionLoaded()
         end
     )
     Ext.Osiris.RegisterListener("LevelGameplayStarted",2,"after",function(_,_)
+            _Log(DummySessionContext(), 1, "LevelGameplayStarted")
             SessionContext.Log(1, string.format("LevelGameplayStarted: Computing Lists"))
 
             SessionContext.EntityCache = {}

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/BootstrapServer.lua
@@ -3199,7 +3199,7 @@ function ComputeConfigHash(sessionContext)
         IterateUserdata = true,
         AvoidRecursion = false,
     }
-    local stringifiedConfig = Ext.Json.Stringify(sessionContext.VarsJson)
+    local stringifiedConfig = Ext.Json.Stringify(FilterTable(function(k, v) return k ~= "DebugMode" or k ~= "Verbosity" end, sessionContext.VarsJson))
     return ConsistentHash(CONFIG_HASH_SALT, #stringifiedConfig * 256, stringifiedConfig)
 end
 

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/Meta.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/Meta.lua
@@ -122,7 +122,7 @@
 --- @field SpellRoots table<string, boolean>
 
 --- @class SessionContext
---- @field VarsJson table
+--- @field VarsJson Config
 --- @field SpellsAdded table<Guid, table<Guid, string[]>>
 --- @field PassivesAdded table<Guid, table<Guid, string[]>>
 --- @field ImplicatedGuids table<Guid, table<Guid, string[]>>
@@ -286,6 +286,12 @@
 --- @field BlacklistedLists BlacklistConfig
 --- @field AbilityDependencies table<string, string[]>
 --- @field PassiveDependencies table<string, string[]>
+--- @field Enemies EntityConfig
+--- @field Bosses EntityConfig
+--- @field Allies EntityConfig
+--- @field Followers EntityConfig
+--- @field FollowersBosses EntityConfig
+--- @field Summons EntityConfig
 
 
 

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/Meta.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/Meta.lua
@@ -141,7 +141,7 @@
 --- @field AbilityDependencies table<string, string[]> | nil
 --- @field PassiveDependencies table<string, string[]> | nil
 --- @field Archetypes table<string>
---- @field SessionLoaded boolean
+--- @field ConfigHash integer
 
 --- @class LevelScaledBoostConfig
 --- @field StaticBoost integer

--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/meta.lsx
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/meta.lsx
@@ -22,10 +22,10 @@
           <attribute id="Tags" type="LSString" value="" />
           <attribute id="Type" type="FixedString" value="Add-on" />
           <attribute id="UUID" type="FixedString" value="ed610c38-785d-45b3-b2eb-6d4c46b67c75" />
-          <attribute id="Version" type="int64" value="1266645985132544" />
+          <attribute id="Version" type="int64" value="1266648132616192" />
           <children>
             <node id="PublishVersion">
-              <attribute id="Version" type="int64" value="1266645985132544" />
+              <attribute id="Version" type="int64" value="1266648132616192" />
             </node>
             <node id="Scripts" />
             <node id="TargetModes">


### PR DESCRIPTION
**Features**
- feat: On new vars load compute hash + store it
- feat: Store current config hash in UserVar, guard reboost with it
- feat: New logic for what boost does with hash
- feat: More stable ConfigHash
- feat: Restore boosts on game load
- feat: Allow config sections to inherit
- feat: Add spells with SpellCastingAbility

**Fixes**
- fix: Load config on level load
- fix(internal): fix bad global usage typo
- fix: propegate force on removeing
- fix: use correct list when un/re boosting

**Internal**
- NestedTable ops and Fold and IsList
- Add helper for boosting list of entities, and waiting on boost drop
- Convert all un/boosting to use list functions and boost drop waiting
- Setup UserVars in one place
- force flag for removing boosting
- Switch to using hash of json for stability
- more info from unboosting
- In Dev mode, log events
- fix bad global usage typo
- DeepCopy and Reverse helpers

