### PR TITLE
feat: Defaults block, Inherited when no "Inherits"

### DIFF
--- a/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/Meta.lua
+++ b/LoreCombatConfigurator/Mods/LoreCombatConfigurator/ScriptExtender/Lua/Meta.lua
@@ -290,6 +290,7 @@
 --- @field BlacklistedLists BlacklistConfig
 --- @field AbilityDependencies table<string, string[]>
 --- @field PassiveDependencies table<string, string[]>
+--- @field Defaults EntityConfig
 --- @field Enemies EntityConfig
 --- @field Bosses EntityConfig
 --- @field Allies EntityConfig


### PR DESCRIPTION
Add a Defaults top level config that will be used to inherit/fallback
  to when no "Inherits" block is found. This can be used to simplify
  configs even more, especially when combined with normal "Inherits"
  block.

See: #35